### PR TITLE
Fix Import File Name Mismatches for yarn Commands

### DIFF
--- a/src/entities/book.entity.ts
+++ b/src/entities/book.entity.ts
@@ -1,5 +1,5 @@
 import { Cascade, Collection, Entity, ManyToMany, ManyToOne, Property } from '@mikro-orm/core';
-import BookValidator from 'contracts/validators/Book.validator';
+import BookValidator from 'contracts/validators/book.validator';
 import { Author } from 'entities/author.entity';
 import { Publisher } from 'entities/publisher.entity';
 import { Tag } from 'entities/tag.entity';

--- a/src/resolvers/author.resolver.ts
+++ b/src/resolvers/author.resolver.ts
@@ -1,4 +1,4 @@
-import AuthorValidator from 'contracts/validators/Author.validator';
+import AuthorValidator from 'contracts/validators/author.validator';
 import { Author } from 'entities/author.entity';
 import { GraphQLResolveInfo } from 'graphql';
 import fieldsToRelations from 'graphql-fields-to-relations';

--- a/src/resolvers/book.resolver.ts
+++ b/src/resolvers/book.resolver.ts
@@ -1,4 +1,4 @@
-import BookValidator from 'contracts/validators/Book.validator';
+import BookValidator from 'contracts/validators/book.validator';
 import { Author } from 'entities/author.entity';
 import { Book } from 'entities/book.entity';
 import { Publisher } from 'entities/publisher.entity';


### PR DESCRIPTION
## Issue:
After cloning the repository and following the installation instructions, I encountered errors when running the following commands:

`yarn loadFixtures`
`yarn dev`
`yarn start`

The errors indicate that there are mismatches between file names imported in the code and the actual file names in the repository.

## Summary of Changes:

- Corrected file name discrepancies to ensure consistency between the imported file names and the actual file names in the codebase.
- Verified that the yarn loadFixtures, yarn dev, and yarn start commands now execute without errors.
